### PR TITLE
Port for rscala 2.2.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,8 +10,8 @@ License: Artistic-2.0
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 6.0.1
-Imports: httr, GenomicRanges, rtracklayer, data.table, utils, plyr, xml2, methods, S4Vectors, dplyr
-Depends: R(>= 3.3.2), rscala(<= 1.0.15)
+Imports: rscala(>= 2.2.2), httr, GenomicRanges, rtracklayer, data.table, utils, plyr, xml2, methods, S4Vectors, dplyr
+Depends: R(>= 3.3.2)
 VignetteBuilder: knitr
 Suggests: BiocStyle, knitr, rmarkdown
 biocViews: Software,Infrastructure,DataImport

--- a/R/Read.R
+++ b/R/Read.R
@@ -47,8 +47,6 @@ initGMQL <- function(output_format, remote_processing = FALSE)
      && !identical(out_format,"COLLECT"))
     stop("output_format must be TAB, GTF or COLLECT")
 
-  scalaCompiler <- rscala::scala(classpath = './inst/java/GMQL.jar',command.line.options = "-J-Xmx4g")
-  assign("WrappeR",scalaCompiler$do('it.polimi.genomics.r.Wrapper'),.GlobalEnv)
   WrappeR$initGMQL(out_format,remote_processing)
 }
 

--- a/R/onLoad.R
+++ b/R/onLoad.R
@@ -1,0 +1,10 @@
+.onLoad <- function(libname, pkgname) {
+  .rscalaPackage(pkgname, heap.maximum = "4g")
+  ## Assign 'WrappeR' to package environment before it is sealed, but don't fulfill promise until needed.
+  assign("WrappeR",s$.it.polimi.genomics.r.Wrapper,envir=parent.env(environment()))
+}
+
+.onUnload <- function(libpath) {
+  .rscalaPackageUnload()
+}
+


### PR DESCRIPTION
This pull request ports the GMQL package to rscala 2.2.2.  Notice that the GMQL.jar was moved from inst/java/ to inst/java/scala-2.11 because you seem to be compiling the Scala code against Scala 2.11.x.  You can also provide a JAR file for users of Scala 2.10.x and Scala 2.12.x by placing JARs in inst/java/scala-2.10 and inst/java/scala-2.12.  JAR files from Java (that will work with any version of Scala) can be in inst/java.  By the way, the JAR file can be reduced by not including the Scala classes.