### PR TITLE
Set "major.version" in .rscalaPackage function.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ License: Artistic-2.0
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 6.0.1
-Imports: rscala(>= 2.2.3), httr, GenomicRanges, rtracklayer, data.table, utils, plyr, xml2, methods, S4Vectors, dplyr
+Imports: rscala(>= 2.4.0), httr, GenomicRanges, rtracklayer, data.table, utils, plyr, xml2, methods, S4Vectors, dplyr
 Depends: R(>= 3.3.2)
 VignetteBuilder: knitr
 Suggests: BiocStyle, knitr, rmarkdown

--- a/R/onLoad.R
+++ b/R/onLoad.R
@@ -1,5 +1,5 @@
 .onLoad <- function(libname, pkgname) {
-  .rscalaPackage(pkgname, heap.maximum = "4g",serialize.output=TRUE)
+  .rscalaPackage(pkgname, heap.maximum = "4g",serialize.output=TRUE, major.release=c("2.11"))
   ## Assign 'WrappeR' to package environment before it is sealed, but don't fulfill promise until needed.
   assign("WrappeR",s$.it.polimi.genomics.r.Wrapper,envir=parent.env(environment()))
 


### PR DESCRIPTION
This is a simple fixed to reflect the fact that you are only providing JAR files for Scala 2.11.  Users of your package will have install Scala 2.11 specifically.  They can do this using rscala::scalaInstall("2.11").

If you want your package to be able to use Scala 2.10, 2.11, or 2.12, you need to provide JARs for these versions as well.  You can easily cross compile for different Scala version by adding the following to your build.sbt:

crossScalaVersions := Seq("2.10.6", "2.11.11", "2.12.3")

The resulting JAR files are placed in your package at inst/jar/scala-2.10, inst/jar/scala-2.11, and inst/jar/scala-2.12.